### PR TITLE
support windows console output

### DIFF
--- a/ppm.cpp
+++ b/ppm.cpp
@@ -151,6 +151,9 @@ void FrameExporter::dumpThr() {
 PPMExporter::PPMExporter(std::string outputfile) {
 
     if(outputfile == "-") {
+#ifdef _WIN32
+        _setmode( _fileno( stdout ), _O_BINARY );
+#endif // _WIN32
         output = &std::cout;
 
     } else {

--- a/ppm.h
+++ b/ppm.h
@@ -18,6 +18,11 @@
 #ifndef PPM_FRAME_EXPORTER_H
 #define PPM_FRAME_EXPORTER_H
 
+#ifdef _WIN32
+#   include <io.h>
+#   include <fcntl.h>
+#endif // _WIN32
+
 #include <iostream>
 #include <fstream>
 #include <ostream>

--- a/settings.cpp
+++ b/settings.cpp
@@ -392,11 +392,6 @@ void SDLAppSettings::importDisplaySettings(ConfFile& conffile) {
 
         output_ppm_filename = entry->getString();
 
-#ifdef _WIN32
-        if(output_ppm_filename == "-") {
-            conffile.entryException(entry, "stdout PPM mode not supported on Windows");
-        }
-#endif
     }
 
     if((entry = display_settings->getEntry("output-framerate")) != 0) {


### PR DESCRIPTION
These minimum changes seem enough to allow -o,--output-ppm-stream [Gource](https://github.com/acaudwell/Gource) options to redirect to stdout in Windows.
Tested with mingw32 gcc - [binary available here](https://circulosmeos.wordpress.com/2017/01/15/axolotl-statistics-script-and-gource-animation/).