### PR TITLE
Added getHeight to FxFont.

### DIFF
--- a/fxfont.cpp
+++ b/fxfont.cpp
@@ -511,6 +511,10 @@ float FXFont::getWidth(const std::string& text) const {
     return glyphset->getWidth(text);
 }
 
+float FXFont::getHeight() const {
+    return glm::ceil(getAscender() + getDescender());
+}
+
 float FXFont::getAscender() const {
     return glyphset->getAscender();
 }
@@ -559,7 +563,7 @@ void FXFont::draw(float x, float y, const std::string& text) const {
     }
 
     if(align_top) {
-        y += glm::ceil(getAscender() + getDescender());
+        y += getHeight();
     }
 
     if(round) {

--- a/fxfont.h
+++ b/fxfont.h
@@ -197,6 +197,7 @@ public:
     void draw(float x, float y, const std::string& text) const;
 
     float getWidth(const std::string& text) const;
+    float getHeight() const;
 
     float getAscender() const;
     float getDescender() const;


### PR DESCRIPTION
This is necessary to allow a smooth moving of the text when we want to change "alignTop" without using the alignTop function, because this function leads to an immediate change.

See also https://github.com/acaudwell/Gource/pull/174#issuecomment-424165778