### PR TITLE
Micro patches

### DIFF
--- a/seeklog.cpp
+++ b/seeklog.cpp
@@ -111,7 +111,10 @@ bool SeekLog::readFully() {
 
     file_size = file->tellg();
 
-    if(!file->is_open()) return false;
+    if(!file->is_open()) {
+        delete file;
+        return false;
+    }
 
     file->seekg (0, std::ios::beg);
 

--- a/stringhash.cpp
+++ b/stringhash.cpp
@@ -74,9 +74,7 @@ vec3 colourHash(const std::string& str) {
     if(hash == 0) hash++;
 
     int r = (hash/7) % 255;
-    if(r<0) r=0;
     int g = (hash/3) % 255;
-    if(g<0) g=0;
     int b = hash % 255;
 
     vec3 colour = normalise(vec3(r, g, b));


### PR DESCRIPTION
Hello,

Two micro patches that I've found with static analysis.
I'd like to ask: why don't you use `math.h` and redefine pi in `pi.h`?

Thanks!