### PR TITLE
fix-mismatched-new-delete

### DIFF
--- a/shader.cpp
+++ b/shader.cpp
@@ -120,7 +120,7 @@ void ShaderPass::checkError() {
         glGetShaderInfoLog(shader_object, info_log_length, &info_log_length, info_log);
 
         std::string info_log_str(info_log);
-        delete info_log;
+        delete [] info_log;
 
         std::string context;
         if(!errorContext(info_log_str, context))
@@ -294,7 +294,7 @@ void Shader::checkProgramError() {
         } else if(Logger::getDefault()->getLevel() == LOG_LEVEL_WARN) {
             warnLog("shader '%s' warning:\n%s", resource_desc, info_log);
         }
-        delete info_log;
+        delete [] info_log;
     }
 
     if(!link_success) {


### PR DESCRIPTION
to avoid:

```
src/core/shader.cpp:123:9: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
        delete info_log;
        ^
              []
src/core/shader.cpp:119:26: note: allocated with 'new[]' here
        char* info_log = new char[info_log_length];
                         ^
src/core/shader.cpp:297:9: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
        delete info_log;
        ^
              []
src/core/shader.cpp:289:26: note: allocated with 'new[]' here
        char* info_log = new char[info_log_length];
```