### PR TITLE
Fix so that GLEW runs on Wayland

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -137,7 +137,7 @@ void SDLAppDisplay::setupExtensions() {
 
     GLenum err = glewInit();
 
-    if (GLEW_OK != err) {
+    if (GLEW_OK != err && GLEW_ERROR_NO_GLX_DISPLAY != err) {
         /* Problem: glewInit failed, something is seriously wrong. */
         char glewerr[1024];
         snprintf(glewerr, 1024, "GLEW Error: %s", glewGetErrorString(err));


### PR DESCRIPTION
When GLEW starts on Wayland, it returns GLEW_ERROR_NO_GLX_DISPLAY because it's Wayland and not X.  Checking for and ignoring this one specific error allows the code to run successfully on Fedora 36 which natively ships with Wayland.

See https://github.com/nigels-com/glew/issues/172

Signed-off-by: Ed Beroset <beroset@ieee.org>