### PR TITLE
add check for return value of FT_Glyph_To_Bitmap()

### DIFF
--- a/fxfont.cpp
+++ b/fxfont.cpp
@@ -78,7 +78,8 @@ FXGlyph::FXGlyph(FXGlyphSet* set, unsigned int chr) {
     FT_Glyph_Metrics *metrics = &ft_face->glyph->metrics;
     height = glm::ceil(metrics->height / 64.0);
 
-    FT_Glyph_To_Bitmap( &ftglyph, FT_RENDER_MODE_NORMAL, 0, 1 );
+    if(FT_Glyph_To_Bitmap( &ftglyph, FT_RENDER_MODE_NORMAL, 0, 1 ))
+		throw FXFontException(ft_face->family_name);
 
     glyph_bitmap = (FT_BitmapGlyph)ftglyph;
 


### PR DESCRIPTION
`FT_Glyph_To_Bitmap()` can fail (for example, due to a failed memory allocation in `ft_new_glyph()` that is called by `FT_Glyph_To_Bitmap()`) and would return a non-zero value to signal an error. This patch adds a check to the return value of `FT_Glyph_To_Bitmap()` to check for non-zero return value and throw an exception in case of error.