### PR TITLE
Fix texture loading for indexed images by converting to RGBA format

### DIFF
--- a/texture.cpp
+++ b/texture.cpp
@@ -259,6 +259,16 @@ void TextureResource::load(bool reload) {
 
         if(surface==0) throw TextureException(filename);
 
+        // Convert indexed images to RGBA for OpenGL compatibility
+        if(surface->format->BytesPerPixel == 1) {
+            SDL_Surface* converted = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_RGBA32, 0);
+            SDL_FreeSurface(surface);
+            surface = converted;
+            if(surface == 0) {
+                throw TextureException(filename);
+            }
+        }
+
         w = surface->w;
         h = surface->h;
 


### PR DESCRIPTION
When using Gource I encountered the problem that some user avatar images caused the program to exit
`gource: failed to load resource './avatars/test.png'`
The problem was that these images were indexed images.

To fix this this PR converts the images to RGBA